### PR TITLE
feat: add link to player page and adjust playlist container margin

### DIFF
--- a/src/app/(tracker)/page.tsx
+++ b/src/app/(tracker)/page.tsx
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import Link from 'next/link';
+
 import { AppSidebar } from '@/components/app-sidebar';
 import { DataTable } from '@/components/data-table';
 import { Icons } from '@/components/icons';
@@ -6,6 +8,7 @@ import { MusicPlayer } from '@/components/music-player/music-player';
 import { RecentSongsFilters } from '@/components/recent-songs-filters';
 import { RecentSongsList } from '@/components/recent-songs-list';
 import SearchInput from '@/components/search-input';
+import { Button, buttonVariants } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import {
   SidebarInset,
@@ -13,6 +16,7 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar';
 import { getRecentTracks } from '@/lib/fetch-data';
+import { cn } from '@/lib/utils';
 
 export default async function Page() {
   const data = await getRecentTracks();
@@ -36,6 +40,15 @@ export default async function Page() {
       <div className="mx-4 mt-2 flex items-center gap-2 md:mx-8 md:mt-4">
         <Icons.logo size={48} className="h-[50px] w-8 md:h-[75px] md:w-12" />
         <h1 className="text-xl md:text-2xl">Carti Tracker</h1>
+        <Link
+          href="/player"
+          className={cn(
+            buttonVariants({ variant: 'outline', size: 'sm' }),
+            'ml-2'
+          )}
+        >
+          Go to Player
+        </Link>
       </div>
       <RecentSongsFilters data={data} />
       <RecentSongsList data={data} />

--- a/src/features/player/components/playlists/optimistic-playlists.tsx
+++ b/src/features/player/components/playlists/optimistic-playlists.tsx
@@ -199,7 +199,7 @@ export function OptimisticPlaylists({
       </div>
       <ul
         ref={playlistsContainerRef}
-        className="mt-px space-y-0.5 text-xs"
+        className="mb-20 mt-px space-y-0.5 text-xs"
         onKeyDown={(e) => handleKeyNavigation(e, 'sidebar')}
       >
         {playlists.map((playlist) => (


### PR DESCRIPTION
This pull request includes changes to the `src/app/(tracker)/page.tsx` and `src/features/player/components/playlists/optimistic-playlists.tsx` files to enhance the user interface and improve navigation. The most important changes include adding a new link to the music player page and adjusting the styling of the playlists container.

### Enhancements to user interface:

* [`src/app/(tracker)/page.tsx`](diffhunk://#diff-ed3c37752187f60e0321750d8f8f4e4916ec08bcdad7bcae35251067fc69efd5R2-R19): Imported `Link` from 'next/link' and added a new link to the music player page with the text "Go to Player" and specific styling. [[1]](diffhunk://#diff-ed3c37752187f60e0321750d8f8f4e4916ec08bcdad7bcae35251067fc69efd5R2-R19) [[2]](diffhunk://#diff-ed3c37752187f60e0321750d8f8f4e4916ec08bcdad7bcae35251067fc69efd5R43-R51)

### Styling adjustments:

* [`src/features/player/components/playlists/optimistic-playlists.tsx`](diffhunk://#diff-d6a6090740d6e27a2c710982d557664bab6c8d590f64abc83d5534e495863b5aL202-R202): Modified the class of the playlists container to include a bottom margin (`mb-20`) for better spacing.